### PR TITLE
Remove "catch all" try/catch blocks

### DIFF
--- a/src/Command/OptionsCommand.cs
+++ b/src/Command/OptionsCommand.cs
@@ -123,54 +123,40 @@ namespace dotnet.nuget.tree.Command
         private static List<ProjectPackage> GetPackages(string fullProjectPath)
         {
             var packages = new List<ProjectPackage>();
-            try
-            {
-                var projDefinition = XDocument.Load(fullProjectPath);
-                packages = projDefinition
-                    .Element("Project")
-                    .Elements("ItemGroup")
-                    .Elements("PackageReference")
-                    .Select(e => new ProjectPackage
-                    {
-                        Name = e.Attribute("Include").Value,
-                        Version = e.Attribute("Version").Value
-                    })
-                    .ToList();
-            }
-            catch (Exception ex)
-            {
-                throw ex;
-            }
+            var projDefinition = XDocument.Load(fullProjectPath);
+            packages = projDefinition
+                .Element("Project")
+                .Elements("ItemGroup")
+                .Elements("PackageReference")
+                .Select(e => new ProjectPackage
+                {
+                    Name = e.Attribute("Include").Value,
+                    Version = e.Attribute("Version").Value
+                })
+                .ToList();
             return packages;
         }
 
         private static List<string> GetTargetFrameworks(string fullProjectPath)
         {
             var targetFrameworksList = new List<string>();
-            try
+            var projDefinition = XDocument.Load(fullProjectPath);
+            var targetFramework = projDefinition
+                .Element("Project")
+                .Elements("PropertyGroup")
+                .Elements("TargetFramework")
+                .Select(e => e.Value)
+                .FirstOrDefault();
+            if (!string.IsNullOrEmpty(targetFramework)) targetFrameworksList.Add(targetFramework);
+            else
             {
-                var projDefinition = XDocument.Load(fullProjectPath);
-                var targetFramework = projDefinition
+                var targetFrameworks = projDefinition
                     .Element("Project")
                     .Elements("PropertyGroup")
-                    .Elements("TargetFramework")
+                    .Elements("TargetFrameworks")
                     .Select(e => e.Value)
                     .FirstOrDefault();
-                if (!string.IsNullOrEmpty(targetFramework)) targetFrameworksList.Add(targetFramework);
-                else
-                {
-                    var targetFrameworks = projDefinition
-                        .Element("Project")
-                        .Elements("PropertyGroup")
-                        .Elements("TargetFrameworks")
-                        .Select(e => e.Value)
-                        .FirstOrDefault();
-                    if (!string.IsNullOrEmpty(targetFrameworks)) targetFrameworksList.AddRange(targetFrameworks.Split(";"));
-                }
-            }
-            catch (Exception ex)
-            {
-                throw ex;
+                if (!string.IsNullOrEmpty(targetFrameworks)) targetFrameworksList.AddRange(targetFrameworks.Split(";"));
             }
             return targetFrameworksList;
         }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -50,10 +50,6 @@ namespace dotnet.nuget.tree
                 Console.WriteLine(ex.Message + "\n");
                 HelpCommand.WriteHelp();
             }
-            catch (Exception ex)
-            {
-                throw ex;
-            }
         }
 
         private static void PrintTree(OptionsCommand options)


### PR DESCRIPTION
This exception catch changes the message reported when an error, and loses its history of where the error came from.

Before this change:
```
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at dotnet.nuget.tree.Program.Main(String[] args) in /home/runner/work/dotnet-nuget-tree/dotnet-nuget-tree/src/Program.cs:line 55
   at dotnet.nuget.tree.Program.<Main>(String[] args)
```

After this change:
```
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at dotnet.nuget.tree.Command.OptionsCommand.GetPackages(String fullProjectPath) in E:\Dev\External\dotnet-nuget-tree\src\Command\OptionsCommand.cs:line 142
   at dotnet.nuget.tree.Command.OptionsCommand.Parse(String[] args) in E:\Dev\External\dotnet-nuget-tree\src\Command\OptionsCommand.cs:line 88
   at dotnet.nuget.tree.Program.Main(String[] args) in E:\Dev\External\dotnet-nuget-tree\src\Program.cs:line 42
   at dotnet.nuget.tree.Program.<Main>(String[] args)
```