### PR TITLE
Cache results of all HTTP requests to improve perf.

### DIFF
--- a/src/Command/HelpCommand.cs
+++ b/src/Command/HelpCommand.cs
@@ -28,6 +28,7 @@ namespace dotnet.nuget.tree.Command
             Console.WriteLine("  -h, --help            Show command line help.");
             Console.WriteLine("  -d, --deep            Deep search tree, default 2.");
             Console.WriteLine("  -t, --tree            Output like a tree packages, default true.");
+            Console.WriteLine("  --disable-cache       Disable cache of packages, default false.");
             // Console.WriteLine("  -c, --configuration   Load custom nuget.config, e.g. for private nugets.");
         }
     }

--- a/src/Command/OptionsCommand.cs
+++ b/src/Command/OptionsCommand.cs
@@ -15,10 +15,11 @@ namespace dotnet.nuget.tree.Command
         public string OutputDir { get; set; }
         public bool Tree { get; set; } = true;
         public bool Verbosity { get; set; } = false;
+        public bool DisableCache { get; set; } = false;
 
         public OptionsCommand() => PathProject = Path.GetFullPath(".");
 
-        public override string ToString() => $"Options [-d {Deep} -t {Tree} -v {Verbosity} {PathProject}]";
+        public override string ToString() => $"Options [-d {Deep} -t {Tree} -v {Verbosity} --disable-cache {DisableCache} {PathProject}]";
 
         public static OptionsCommand Parse(string[] args)
         {
@@ -28,6 +29,7 @@ namespace dotnet.nuget.tree.Command
                 "-d", "--deep",
                 "-v", "--verbosity",
                 "-t", "--tree",
+                "--disable-cache",
             };
             var optionsCommand = new OptionsCommand();
             for (var i = 0; i < args.Length; i++)
@@ -74,6 +76,9 @@ namespace dotnet.nuget.tree.Command
                             throw new ArgumentException($"Unknown value {argName}={argValue}; expects true or false.");
                         optionsCommand.Tree = tree;
                         break;
+                    case "--disable-cache":
+                        optionsCommand.DisableCache = true;
+                        break;
                     default:
                         optionsCommand.PathProject = Path.GetFullPath(argValue);
                         break;
@@ -98,7 +103,7 @@ namespace dotnet.nuget.tree.Command
             return optionsCommand;
         }
 
-        private static bool ArgWithoutValue(string arg) => new[] { "-v", "--verbosity" }.Contains(arg);
+        private static bool ArgWithoutValue(string arg) => new[] { "-v", "--verbosity", "--disable-cache" }.Contains(arg);
 
         public static List<string> ResolveProjectFile(string path)
         {

--- a/src/PackageLoader.cs
+++ b/src/PackageLoader.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace dotnet.nuget.tree
+{
+    internal class PackageLoader
+    {
+        private readonly HttpClient _httpClient = new HttpClient();
+        private readonly ConcurrentDictionary<string, Task<ExpandoObject>> _cache = new ConcurrentDictionary<string, Task<ExpandoObject>>();
+        internal int _cacheHits = 0;
+        private readonly bool _disableCache = false;
+
+        internal PackageLoader(bool disableCache)
+        {
+            _disableCache = disableCache;
+        }
+
+        internal async IAsyncEnumerable<ProjectPackage> GetDependenciesForProject(Project project, string name, string version)
+        {
+            dynamic packageJson = await GetWithCache($"https://api.nuget.org/v3/registration5-semver1/{name.ToLower()}/{version.ToLower()}.json");
+            if (packageJson == null) yield break;
+
+            dynamic packageDefinition = await GetWithCache(packageJson.catalogEntry);
+            if (!IsPropertyExist(packageDefinition, "dependencyGroups")) yield break;
+
+            foreach (dynamic dependency in packageDefinition.dependencyGroups)
+            {
+                if (!IsPropertyExist(dependency, "targetFramework")) continue;
+                if (!IsPropertyExist(dependency, "dependencies")) continue;
+                if (
+                    project.TargetFrameworks.Any(targetFramework => dependency.targetFramework.ToLower().Contains(targetFramework)) ||
+                    dependency.targetFramework.ToLower().Contains("netstandard")
+                )
+                {
+                    foreach (dynamic packageDependency in dependency.dependencies)
+                    {
+                        yield return new ProjectPackage
+                        {
+                            Name = packageDependency.id,
+                            Version = Regex.Replace(packageDependency.range, @"[\[\],\)\s]", string.Empty)
+                        };
+                    }
+                    continue;
+                }
+            }
+        }
+
+        internal async Task<ExpandoObject> GetWithCache(string uri)
+        {
+            if (_disableCache)
+            {
+                return await _loadData(uri);
+            }
+
+            var cacheHit = true;
+            var result = _cache.GetOrAdd(uri, _loadData);
+
+            if (cacheHit)
+            {
+                Interlocked.Increment(ref _cacheHits);
+            }
+
+            return await result;
+
+            Task<ExpandoObject> _loadData(string _uri)
+            {
+                cacheHit = false;
+                return _httpClient.GetAsync(uri).ContinueWith((response) =>
+                {
+                    if (!response.Result.IsSuccessStatusCode)
+                    {
+                        return null;
+                    }
+
+                    return response.Result.Content.ReadAsAsync<ExpandoObject>();
+                }).ContinueWith((doubleWrapped) => doubleWrapped?.Result?.Result);
+            }
+        }
+
+        private static bool IsPropertyExist(dynamic settings, string name)
+        {
+            if (settings is ExpandoObject)
+                return ((IDictionary<string, object>)settings).ContainsKey(name);
+
+            return settings.GetType().GetProperty(name) != null;
+        }
+    }
+}


### PR DESCRIPTION
A new option `--disable-cache` may be specified to disable the caching.

Simple benchmarking shows considerable improvement for higher depths. For an example repository at depth 4, the results were:

Without cache: 2 minutes
With cache: 21 seconds

Improvements will vary depending on how many duplicate packages there are.